### PR TITLE
fix(ruby): фарнинг при вызове методов цепочной

### DIFF
--- a/ruby.yml
+++ b/ruby.yml
@@ -165,6 +165,16 @@ Style/MultilineOperationIndentation:
   Description: Checks indentation of binary operations that span more than one line.
   Enabled: false
 
+Style/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+  SupportedStyles:
+    - aligned
+    - indented
+    - indented_relative_to_receiver
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
 Metrics/AbcSize:
   Description: A calculated magnitude based on number of assignments, branches, and
     conditions.


### PR DESCRIPTION
чтобы не ругался когда методы вызываются вот так

```ruby
x =
  SomeClass
    .method1
    .method2
```
и так

```ruby
x = SomeClass
      .method1
      .method2
```
![screenshot from 2016-12-02 13 50 56](https://cloud.githubusercontent.com/assets/1196822/20827880/c60e3c6e-b89e-11e6-945d-ebae18b4a0a8.png)
