### PR TITLE
fix(ruby): add TargetRubyVersion

### DIFF
--- a/ruby.yml
+++ b/ruby.yml
@@ -3,6 +3,7 @@ AllCops:
     - db/schema.rb
   Rails:
     Enabled: true
+  TargetRubyVersion: 2.2
 
 Style/AccessorMethodName:
   Description: Check the naming of accessor methods for get_/set_.


### PR DESCRIPTION
Бамп целевой версии руби, чтобы хаунд перестал ругаться на `unexpected token tCOMMA` при использовании required keyword arguments.