### PR TITLE
feat: allow_element_with_attribute set true

### DIFF
--- a/scss.yml
+++ b/scss.yml
@@ -132,7 +132,7 @@ linters:
 
   QualifyingElement:
     enabled: true
-    allow_element_with_attribute: false
+    allow_element_with_attribute: true
     allow_element_with_class: false
     allow_element_with_id: false
 


### PR DESCRIPTION
Периодически в реквестах возникает необходимость использовать атрибуты не к классу, а к элементу. Хочется убрать проверку 