### PR TITLE
chore: disable Lint/AmbiguousBlockAssociation for specs

### DIFF
--- a/ruby.yml
+++ b/ruby.yml
@@ -140,6 +140,10 @@ Style/Lambda:
 
 # Lint
 
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - 'spec/**/*'
+
 Lint/AssignmentInCondition:
   Description: "Don't use assignment in conditions."
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#safe-assignment-in-condition'


### PR DESCRIPTION
Чтобы на тесты Hound не писал
> Parenthesize the param change { ... } to make sure that the block will be associated with the change method call.